### PR TITLE
feat: configure API base URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://localhost:5000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+# Set to your production backend URL
+REACT_APP_API_BASE=

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ This is a comprehensive IELTS Speaking Test evaluation application with advanced
 - Modern web browser (Chrome recommended)
 - Microphone access
 
+## Environment Setup
+
+Create environment files to configure the frontend API base URL:
+
+- `.env.development` – used when running `npm run dev`
+- `.env.production` – used for production builds
+
+Each file should define:
+
+```
+REACT_APP_API_BASE=http://localhost:5000
+```
+
+Set `REACT_APP_API_BASE` to the backend's base URL (omit the trailing slash). For production, replace the value with your deployed backend URL.
+
 ## Installation & Setup
 
 ### 1. Initial Setup

--- a/src/components/SpeechEvaluator.jsx
+++ b/src/components/SpeechEvaluator.jsx
@@ -540,7 +540,7 @@ function SpeechEvaluator() {
     setError(null);
 
     try {
-      const response = await fetch("/api/analyze-batch", {
+      const response = await fetch(`${process.env.REACT_APP_API_BASE}/api/analyze-batch`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add `.env` configs to set `REACT_APP_API_BASE`
- use `REACT_APP_API_BASE` when fetching batch analysis
- document env configuration in README

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68c59fe2d6bc832ba8ea4e9c8c32345d