### PR TITLE
Improve error details for analysis requests

### DIFF
--- a/src/components/SpeechEvaluator.jsx
+++ b/src/components/SpeechEvaluator.jsx
@@ -559,8 +559,17 @@ function SpeechEvaluator() {
       setTestSummary(data.testSummary);
       setShowResults(true);
     } catch (err) {
-      console.error("Analysis error:", err);
-      setError("Error during analysis. Please check your connection and try again.");
+      // Build detailed error message including response info when available
+      let errorMessage = err?.message || "Unknown error";
+      if (err?.response) {
+        const { status, statusText } = err.response;
+        errorMessage += ` (status ${status}${statusText ? `: ${statusText}` : ""})`;
+      }
+
+      console.error("Analysis error:", errorMessage, err);
+      setError(
+        `Analysis failed: ${errorMessage}. Please check your connection or ensure the backend is available.`
+      );
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- surface detailed error information from analysis requests by including error messages and response status in the user-facing alert

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c59fead070832bb99af422803076ad